### PR TITLE
Fix meerkat compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ## 1.4.1 - 2025-04-30
 
+### Changed
+
+- Updated getMinSdkVersion function to avoid usage of deprecated API
+
 ### Fixed
 
 - Plugin not working on AS Meerkat due to missing action update thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Fixed
 
+## 1.4.1 - 2025-04-30
+
+### Fixed
+
 - Plugin not working on AS Meerkat due to missing action update thread
 
 ## 1.4.0 - 2025-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Plugin not working on AS Meerkat due to missing action update thread
+
 ## 1.4.0 - 2025-01-05
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,7 @@ tasks {
 
 val runAndroidStudio by intellijPlatformTesting.runIde.registering {
     type = IntelliJPlatformType.AndroidStudio
-    version = "2024.2.1.9"
+    version = "2024.3.1.2"
 }
 
 tasks.withType(RunIdeTask::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.abeade.plugin.figma
 pluginName = Import Figma Resources
 pluginRepositoryUrl = https://github.com/abeade/figma-import-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.4.0
+pluginVersion = 1.4.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/kotlin/com/abeade/plugin/figma/ImportAction.kt
+++ b/src/main/kotlin/com/abeade/plugin/figma/ImportAction.kt
@@ -5,6 +5,7 @@ import com.android.tools.idea.rendering.webp.ConvertToWebpAction
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
@@ -24,12 +25,14 @@ class ImportAction : AnAction() {
 
     private lateinit var virtualFileRes: VirtualFile
 
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
     override fun update(anActionEvent: AnActionEvent) {
         val project = anActionEvent.project
         val psiElement: PsiElement? = anActionEvent.dataContext.getData(PlatformDataKeys.PSI_ELEMENT)
         val isValid = project != null && psiElement != null &&
                 (psiElement as? PsiDirectoryImpl)?.isDirectory == true &&
-                (psiElement as? PsiDirectoryImpl)?.name == RES_DIRECTORY
+                psiElement.name == RES_DIRECTORY
         anActionEvent.presentation.isEnabledAndVisible = isValid
         if (isValid) {
             virtualFileRes = (psiElement as PsiDirectoryImpl).virtualFile

--- a/src/main/kotlin/com/abeade/plugin/figma/ImportAction.kt
+++ b/src/main/kotlin/com/abeade/plugin/figma/ImportAction.kt
@@ -29,13 +29,12 @@ class ImportAction : AnAction() {
 
     override fun update(anActionEvent: AnActionEvent) {
         val project = anActionEvent.project
-        val psiElement: PsiElement? = anActionEvent.dataContext.getData(PlatformDataKeys.PSI_ELEMENT)
-        val isValid = project != null && psiElement != null &&
-                (psiElement as? PsiDirectoryImpl)?.isDirectory == true &&
-                psiElement.name == RES_DIRECTORY
+        val psiElement = anActionEvent.getData(PlatformDataKeys.PSI_ELEMENT)
+        val resDirectory = psiElement as? PsiDirectoryImpl
+        val isValid = project != null && resDirectory?.isDirectory == true && resDirectory.name == RES_DIRECTORY
         anActionEvent.presentation.isEnabledAndVisible = isValid
         if (isValid) {
-            virtualFileRes = (psiElement as PsiDirectoryImpl).virtualFile
+            virtualFileRes = resDirectory!!.virtualFile
         }
     }
 

--- a/src/main/kotlin/com/abeade/plugin/figma/utils/AnActionEventExtensions.kt
+++ b/src/main/kotlin/com/abeade/plugin/figma/utils/AnActionEventExtensions.kt
@@ -7,8 +7,10 @@ import com.android.tools.idea.model.queryMinSdkAndTargetSdkFromManifestIndex
 import com.android.tools.idea.util.CommonAndroidUtil
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.Project
 import org.jetbrains.android.facet.AndroidFacet
 
 fun AnActionEvent.getMinSdkVersion(): Int {
@@ -17,17 +19,21 @@ fun AnActionEvent.getMinSdkVersion(): Int {
     if (module != null && CommonAndroidUtil.getInstance().isAndroidProject(module.project)) {
         val facet = AndroidFacet.getInstance(module)
         if (facet != null) {
-            val minSdk = getMinSdkVersion(facet)
+            val minSdk = getMinSdkVersion(facet, module.project)
             minSdkVersion = minSdk?.featureLevel ?: Int.MAX_VALUE
         }
     }
     return minSdkVersion
 }
 
-private fun getMinSdkVersion(facet: AndroidFacet): AndroidVersion? = AndroidModel.get(facet)?.minSdkVersion
+private fun getMinSdkVersion(facet: AndroidFacet, project: Project): AndroidVersion? = AndroidModel.get(facet)?.minSdkVersion
     ?: try {
-        DumbService.getInstance(facet.module.project)
-            .runReadActionInSmartMode<AndroidVersion> { facet.queryMinSdkAndTargetSdkFromManifestIndex().minSdk }
+        ReadAction
+            .nonBlocking<AndroidVersion> { facet.queryMinSdkAndTargetSdkFromManifestIndex().minSdk }
+            .inSmartMode(project)
+            .executeSynchronously()
+    } catch (e: ProcessCanceledException) {
+        throw e
     } catch (_: Exception) {
         try {
             MergedManifestManager.getMergedManifestSupplier(facet.module).get().get().minSdkVersion


### PR DESCRIPTION
Fixes error:
```
java.lang.Throwable: 'psi.Element' is requested on EDT by ImportAction#presentation@ProjectViewPopup 
```
This error is caused by accessing PSI (Program Structure Interface) elements on the EDT (Event Dispatch Thread), which is not allowed in recent versions of IntelliJ Platform-based IDEs like Android Studio. The platform enforces this to avoid performance and UI freezing issues.

This PR is using `ActionUpdateThread.BGT` by overriding `getActionUpdateThread` method in the `ImportAction`.
Also replaces the usage of the deprecated API `DumbService.getInstance(project).runReadActionInSmartMode` by using `ReadAction.nonBlocking<T> { }.inSmartMode(project)` instead.

closes #19